### PR TITLE
Add `ParseKwargs` function

### DIFF
--- a/internal/util/assert/assert.go
+++ b/internal/util/assert/assert.go
@@ -1,0 +1,30 @@
+package assert
+
+import (
+	"log"
+	"reflect"
+)
+
+func Eq(lhs, rhs interface{}) {
+	if !reflect.DeepEqual(lhs, rhs) {
+		log.Panicf("Assertion failed:\nLeft != Right\nlhs = `%v`\nrhs = `%v`", lhs, rhs)
+	}
+}
+
+func Ne(lhs, rhs interface{}) {
+	if reflect.DeepEqual(lhs, rhs) {
+		log.Panicf("Assertion failed:\nLeft == Right\nlhs = `%v`\nrhs = `%v`", lhs, rhs)
+	}
+}
+
+func Ok(err error) {
+	if err != nil {
+		log.Panicf("Assertion failed:\nError: `%v`", err)
+	}
+}
+
+func Fail(err error) {
+	if err == nil {
+		log.Panicf("Assertion failed:\nError: `%v` (ok)", err)
+	}
+}

--- a/internal/util/kwargs_test.go
+++ b/internal/util/kwargs_test.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/akl-infra/bot/internal/util/assert"
+	"github.com/akl-infra/bot/internal/util/parser"
+)
+
+func TestKwarg(t *testing.T) {
+	cmdKwargs := map[string]parser.KwargType{
+		"mylist": parser.List,
+		"mybool": parser.Bool,
+		"mystr":  parser.Str,
+	}
+	args, err := parser.ParseKwargs("", parser.Str, cmdKwargs)
+	assert.Eq(args["args"].AsStr(), "")
+	assert.Ok(err)
+
+	args, err = parser.ParseKwargs("a list", parser.List, cmdKwargs)
+	assert.Eq(args["args"].AsList(), []string{"a", "list"})
+
+	args, err = parser.ParseKwargs("hello mylist --mylist 1 2 3", parser.List, cmdKwargs)
+	assert.Eq(args["args"].AsList(), []string{"hello", "mylist"})
+	assert.Eq(args["mylist"].AsList(), []string{"1", "2", "3"})
+
+	args, err = parser.ParseKwargs("hello str --mystr bogos binted", parser.Str, cmdKwargs)
+	assert.Eq(args["args"].AsStr(), "hello str")
+	assert.Eq(args["mystr"].AsStr(), "bogos binted")
+
+	args, err = parser.ParseKwargs("hello bool --mybool", parser.Str, cmdKwargs)
+	assert.Eq(args["args"].AsStr(), "hello bool")
+	assert.Eq(args["mybool"].AsBool(), true)
+
+	args, err = parser.ParseKwargs("hello all --mylist a b --mystr c d --mybool", parser.Str, cmdKwargs)
+	assert.Eq(args["args"].AsStr(), "hello all")
+	assert.Eq(args["mylist"].AsList(), []string{"a", "b"})
+	assert.Eq(args["mystr"].AsStr(), "c d")
+	assert.Eq(args["mybool"].AsBool(), true)
+
+	args, err = parser.ParseKwargs("hello none --invalid --flag", parser.Str, cmdKwargs)
+	assert.Fail(err)
+	assert.Eq(err.Error(), "invalid kwarg: `invalid`")
+	assert.Eq(args, make(map[string]parser.Kwarg))
+
+	args, err = parser.ParseKwargs("--mybool", parser.Str, cmdKwargs)
+	assert.Eq(args["args"].AsStr(), "")
+	assert.Eq(args["mybool"].AsBool(), true)
+	assert.Eq(args["mylist"].AsList(), []string{})
+	assert.Eq(args["mystr"].AsStr(), "")
+
+	args, err = parser.ParseKwargs("many           whitespaces      --mylist    many      whitespaces", parser.Str, cmdKwargs)
+	assert.Eq(args["args"].AsStr(), "many whitespaces")
+	assert.Eq(args["mylist"].AsList(), []string{"many", "whitespaces"})
+
+	args, err = parser.ParseKwargs("--mylist former is original --mylist latter is duplicate", parser.Str, cmdKwargs)
+	assert.Eq(args["mylist"].AsList(), []string{"latter", "is", "duplicate"})
+
+	args, err = parser.ParseKwargs("--MYSTR UPPERCASE", parser.Str, cmdKwargs)
+	assert.Eq(args["mystr"].AsStr(), "UPPERCASE")
+
+	args, err = parser.ParseKwargs("--", parser.Str, cmdKwargs)
+	assert.Fail(err)
+
+	args, err = parser.ParseKwargs("—mystr em dash ––mylist en dash", parser.Str, cmdKwargs)
+	assert.Eq(args["mystr"].AsStr(), "em dash")
+	assert.Eq(args["mylist"].AsList(), []string{"en", "dash"})
+
+	args, err = parser.ParseKwargs("--mybool this text is ignored", parser.Str, cmdKwargs)
+	assert.Eq(args["args"].AsStr(), "")
+	assert.Eq(args["mybool"].AsBool(), true)
+	assert.Eq(args["mystr"].AsStr(), "")
+	assert.Eq(args["mylist"].AsList(), []string{})
+
+}

--- a/internal/util/parser/kwarg_core.go
+++ b/internal/util/parser/kwarg_core.go
@@ -1,0 +1,54 @@
+package parser
+
+import "github.com/akl-infra/bot/internal/util/assert"
+
+type KwargType int
+
+const (
+	Bool KwargType = iota
+	List
+	Str
+)
+
+type Kwarg struct {
+	_type KwargType
+	bool  *bool
+	list  *[]string
+	str   *string
+}
+
+func NewBoolValue(b bool) Kwarg {
+	return Kwarg{
+		_type: Bool,
+		bool:  &b,
+	}
+}
+
+func NewListValue(l []string) Kwarg {
+	return Kwarg{
+		_type: List,
+		list:  &l,
+	}
+}
+
+func NewStrValue(s string) Kwarg {
+	return Kwarg{
+		_type: Str,
+		str:   &s,
+	}
+}
+
+func (k Kwarg) AsBool() bool {
+	assert.Eq(k._type, Bool)
+	return *k.bool
+}
+
+func (k Kwarg) AsList() []string {
+	assert.Eq(k._type, List)
+	return *k.list
+}
+
+func (k Kwarg) AsStr() string {
+	assert.Eq(k._type, Str)
+	return *k.str
+}

--- a/internal/util/parser/kwarg_parser.go
+++ b/internal/util/parser/kwarg_parser.go
@@ -1,0 +1,122 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+var prefixList = []string{"--", "—", "––"}
+
+func ParseKwargs(arg string, argType KwargType, cmdKwargs map[string]KwargType) (map[string]Kwarg, error) {
+	words := strings.Fields(arg)
+	argIndex := 0
+	for _, word := range words {
+		isKwarg, err := isKwarg(cmdKwargs, word)
+		if err != nil {
+			return make(map[string]Kwarg), err
+		}
+		if isKwarg {
+			break
+		}
+		argIndex++
+	}
+
+	// Make default map
+	args := words[:argIndex]
+	parsedKwargs := make(map[string]Kwarg)
+	if argType == List {
+		parsedKwargs["args"] = NewListValue(args)
+	} else {
+		parsedKwargs["args"] = NewStrValue(strings.Join(args, " "))
+	}
+	for kwName, kwType := range cmdKwargs {
+		switch kwType {
+		case Bool:
+			parsedKwargs[kwName] = NewBoolValue(false)
+		case List:
+			parsedKwargs[kwName] = NewListValue([]string{})
+		case Str:
+			parsedKwargs[kwName] = NewStrValue("")
+		}
+	}
+
+	words = words[argIndex:]
+	lastInList := 0
+	lastKwargType := List
+	lastListKwarg := ""
+	inList := false
+
+	for index, word := range words {
+		if ok, _ := isKwarg(cmdKwargs, word); !ok {
+			continue
+		}
+		word = removeKwPrefix(word)
+		kwType := cmdKwargs[word]
+
+		// Encountered next keyword, stops previous list
+		if inList {
+			var value Kwarg
+			if lastKwargType == List {
+				value = NewListValue(words[lastInList:index])
+			} else {
+				value = NewStrValue(strings.Join(words[lastInList:index], " "))
+			}
+			parsedKwargs[lastListKwarg] = value
+		}
+		inList = kwType == List || kwType == Str
+
+		// List | Str: Starts a new list after kwarg
+		if !inList {
+			parsedKwargs[word] = NewBoolValue(true)
+		} else {
+			lastKwargType = kwType
+			lastListKwarg = word
+			lastInList = index + 1
+		}
+	}
+
+	// Close the last list
+	if inList {
+		var value Kwarg
+		if lastKwargType == List {
+			value = NewListValue(words[lastInList:])
+		} else {
+			value = NewStrValue(strings.Join(words[lastInList:], " "))
+		}
+		parsedKwargs[lastListKwarg] = value
+	}
+
+	return parsedKwargs, nil
+}
+
+func startsWithKwPrefix(word string) bool {
+	for _, prefix := range prefixList {
+		if strings.HasPrefix(word, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeKwPrefix(word string) string {
+	word = strings.ToLower(word)
+	for _, prefix := range prefixList {
+		if strings.HasPrefix(word, prefix) {
+			return strings.TrimPrefix(word, prefix)
+		}
+	}
+	return word
+}
+
+func isKwarg(kwargs map[string]KwargType, word string) (bool, error) {
+	if !startsWithKwPrefix(word) {
+		return false, nil
+	}
+	word = removeKwPrefix(word)
+	_, found := kwargs[word]
+	if found {
+		return true, nil
+	} else {
+		return false, fmt.Errorf("invalid kwarg: `%s`", word)
+	}
+}

--- a/internal/util/parser/parser.go
+++ b/internal/util/parser/parser.go
@@ -1,0 +1,3 @@
+package parser
+
+// TODO: Implement other parser logics


### PR DESCRIPTION
### Add `ParseKwargs` function to parse positional (args) and keyword arguments (kwargs)
- added a `util` package, which is not used anywhere currently

### Command structure and rules
- positional args always come before kwargs
- `arg` can be both uppercase and lowercase
- arg types: `string` or `[]string`
- both args and kwargs are optional and have default values
- no whitespace, as it's already used as the word delimiter
- keywords in `map[keyword]keywordType` must be lowercase
- kwarg types: `bool`, `string`, or `[]string`
- kwarg flags start with double hyphen (--), single em dash (—), or double en dash (––)
- if invalid kwargs are found, the function returns `(empty map, error)`
- if duplicate flags are found, the last flag prevails

### Usage
- `args, err := parser.ParseKwargs(...)`
- pass `arg: string`, `parser.List | parser.Str`, `cmdKwargs: map[string]parser.KwargType`
- receive `map[string]parser.Kwarg, error`
- access args with `args["args"].AsStr()` | `args["args"].AsList()`
- access kwargs with `args[kwargName].AsBool()` | `args[kwargName].AsStr()` | `args[kwargName].AsList()`
- names and types must match `cmdKwargs`

### Tests
- run `go test ./internal/util/kwargs_test.go`