### PR TITLE
Refactor dispatcher with interface, add 8ball and github command, fix trigger logic

### DIFF
--- a/internal/cmd/8ball.go
+++ b/internal/cmd/8ball.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/akl-infra/bot/internal/cmd/cmd_core"
+	"golang.org/x/exp/rand"
+	"time"
+)
+
+type EightBall struct{ cmd_core.DefaultCommand }
+
+func (cmd EightBall) Exec(_ string, _ uint64) (string, error) {
+	rand.Seed(uint64(time.Now().UnixNano()))
+	responses := []string{
+		"Yes", "Count on it",
+		"No doubt",
+		"Absolutely", "Very likely",
+		"Maybe", "Perhaps",
+		"No", "No chance", "Unlikely",
+		"Doubtful", "Probably not",
+	}
+	return responses[rand.Intn(len(responses))], nil
+}
+
+func (cmd EightBall) Use() string {
+	return "!akl 8ball"
+}
+
+func (cmd EightBall) Desc() string {
+	return "8ball"
+}

--- a/internal/cmd/cmd_core/core.go
+++ b/internal/cmd/cmd_core/core.go
@@ -1,0 +1,29 @@
+package cmd_core
+
+type Commandable interface {
+	Exec(arg string, uuid uint64) (string, error)
+	Use() string
+	Desc() string
+	Restricted() bool
+	ModsOnly() bool
+}
+
+// DefaultCommand
+// implement `Commandable` with composite:
+//
+//	type ExampleCommand struct { cmd_core.DefaultCommand }
+//
+// required methods: `Exec()`, `Use()`, `Desc()`
+// default methods: `Restricted()`, `ModsOnly()`, returns bool by default
+// override the required methods, and default methods, if necessary
+type DefaultCommand struct{}
+
+func (d DefaultCommand) Exec(_ string, _ uint64) (string, error) {
+	panic("unimplemented")
+}
+func (d DefaultCommand) Use() string      { panic("unimplemented") }
+func (d DefaultCommand) Desc() string     { panic("unimplemented") }
+func (d DefaultCommand) Restricted() bool { return false }
+func (d DefaultCommand) ModsOnly() bool   { return false }
+
+const MaxLayouts = 20

--- a/internal/cmd/github.go
+++ b/internal/cmd/github.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "github.com/akl-infra/bot/internal/cmd/cmd_core"
+
+type Github struct{ cmd_core.DefaultCommand }
+
+func (cmd Github) Exec(_ string, _ uint64) (string, error) {
+	return "<https://github.com/akl-infra>", nil
+}
+
+func (cmd Github) Use() string {
+	return "!akl github"
+}
+
+func (cmd Github) Desc() string {
+	return "github"
+}

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -1,5 +1,19 @@
 package cmd
 
-func Help(command string, args []string) (string, error) {
+import (
+	"github.com/akl-infra/bot/internal/cmd/cmd_core"
+)
+
+type Help struct{ cmd_core.DefaultCommand }
+
+func (cmd Help) Exec(_ string, _ uint64) (string, error) {
 	return "AKL AKL AKL!", nil
+}
+
+func (cmd Help) Use() string {
+	return "!akl help [command]"
+}
+
+func (cmd Help) Desc() string {
+	return "help"
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -3,24 +3,23 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/akl-infra/bot/internal/cmd/cmd_core"
 	"io"
 	"strings"
 
 	"github.com/akl-infra/bot/internal/api"
 )
 
-type Layouts []string
+type List struct{ cmd_core.DefaultCommand }
 
-const MaxLayouts = 20
-
-func List(command string, args []string) (string, error) {
+func (cmd List) Exec(_ string, _ uint64) (string, error) {
 	res, err := api.Get("layouts")
 	if err != nil {
 		return "Error contacting API", err
 	}
 	defer res.Body.Close()
 	var body []byte
-	var layouts Layouts
+	var layouts []string
 	body, err = io.ReadAll(res.Body)
 	if err != nil {
 		return "Error reading response from API", err
@@ -31,12 +30,12 @@ func List(command string, args []string) (string, error) {
 
 	numLayouts := len(layouts)
 	var msg string
-	if numLayouts > MaxLayouts {
-		trimmed := strings.Join(layouts[:MaxLayouts], "\n")
+	if numLayouts > cmd_core.MaxLayouts {
+		trimmed := strings.Join(layouts[:cmd_core.MaxLayouts], "\n")
 		msg = fmt.Sprintf(
 			"Found %d layouts: showing first %d\n"+
 				"%s",
-			numLayouts, MaxLayouts, trimmed,
+			numLayouts, cmd_core.MaxLayouts, trimmed,
 		)
 	} else {
 		msg = fmt.Sprintf(
@@ -46,4 +45,12 @@ func List(command string, args []string) (string, error) {
 		)
 	}
 	return msg, nil
+}
+
+func (cmd List) Use() string {
+	return "!akl list"
+}
+
+func (cmd List) Desc() string {
+	return "list layout names"
 }

--- a/internal/cmd/ping.go
+++ b/internal/cmd/ping.go
@@ -2,9 +2,22 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/akl-infra/bot/internal/cmd/cmd_core"
+	"github.com/akl-infra/bot/internal/util/parser"
 	"strings"
 )
 
-func Ping(command string, args []string) (string, error) {
-	return fmt.Sprintf("%s: [%s]", command, strings.Join(args, ",")), nil
+type Ping struct{ cmd_core.DefaultCommand }
+
+func (cmd Ping) Exec(arg string, _ uint64) (string, error) {
+	args := parser.ParseQuotedArgs(arg)
+	return fmt.Sprintf("ping: [%s]", strings.Join(args, ",")), nil
+}
+
+func (cmd Ping) Use() string {
+	return "!akl ping"
+}
+
+func (cmd Ping) Desc() string {
+	return "ping"
 }

--- a/internal/cmd/view.go
+++ b/internal/cmd/view.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/akl-infra/bot/internal/cmd/cmd_core"
+	"github.com/akl-infra/bot/internal/util/parser"
 	"io"
 	"strings"
 
@@ -10,7 +12,10 @@ import (
 	"github.com/akl-infra/slf/v2"
 )
 
-func View(command string, args []string) (string, error) {
+type View struct{ cmd_core.DefaultCommand }
+
+func (cmd View) Exec(arg string, _ uint64) (string, error) {
+	args := parser.ParseArgs(arg)
 	if len(args) == 0 {
 		return "No layout specified", nil
 	}
@@ -50,4 +55,12 @@ func View(command string, args []string) (string, error) {
 	}
 
 	return sb.String(), nil
+}
+
+func (cmd View) Use() string {
+	return "!akl view"
+}
+
+func (cmd View) Desc() string {
+	return "view layouts"
 }

--- a/internal/handler/callbacks.go
+++ b/internal/handler/callbacks.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
@@ -9,12 +10,6 @@ import (
 )
 
 const Trigger = "!akl"
-
-func parseArgs(str string) []string {
-	re := regexp.MustCompile(`[^\s"']+|"([^"]*)"|'([^']*)'`)
-	matches := re.FindAllString(str, -1)
-	return matches
-}
 
 func OnReady(s *discordgo.Session, r *discordgo.Ready) {
 	log.Info("Bot is ready")
@@ -73,20 +68,20 @@ func OnMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	var reply string
-	args := parseArgs(content)
-	if len(args) == 0 {
+	if content == "" {
 		reply = "No command provided"
 	} else {
-		command := args[0]
-		if len(args) > 1 {
-			args = args[1:]
-		} else {
-			args = []string{}
+		commandArg := strings.SplitN(content, " ", 2)
+		command := commandArg[0]
+		arg := ""
+		if len(commandArg) > 1 {
+			arg = commandArg[1]
 		}
+		id, _ := strconv.ParseUint(m.Author.ID, 10, 64)
 
-		reply, err = Dispatch(command, args)
+		reply, err = Dispatch(command, arg, id)
 		if err != nil {
-			log.Errorf("Error in command: %s %s => %s", command, args, err)
+			log.Errorf("Error in command: %s %s => %s", command, arg, err)
 		}
 	}
 	if _, err = s.ChannelMessageSendReply(m.ChannelID, reply, m.Reference()); err != nil {

--- a/internal/handler/callbacks.go
+++ b/internal/handler/callbacks.go
@@ -55,11 +55,12 @@ func OnMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	if !(isDM || isMention) {
 		var ok bool
 		if strings.HasPrefix(m.Content, "!") {
-			content, ok = strings.CutPrefix(content, Trigger+" ")
+			content, ok = strings.CutPrefix(content, Trigger)
 			if !ok {
 				log.Info("Didn't find trigger")
 				return
 			}
+			content = strings.TrimLeft(content, " ")
 		} else {
 			// Ignore unprefixed channel messages
 			return

--- a/internal/handler/callbacks.go
+++ b/internal/handler/callbacks.go
@@ -38,7 +38,7 @@ func OnMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	// Match user/nick/role/channel mentions
-	mentionRegex := regexp.MustCompile(`^(<@!?\d+>\s+|<@&\d+>\s+|<#\d+>\s+)`)
+	mentionRegex := regexp.MustCompile(`<@!?\d+>|<@&\d+>|<#\d+>`)
 
 	// Remove mentions from the message content
 	content := mentionRegex.ReplaceAllString(m.Content, "")

--- a/internal/handler/callbacks.go
+++ b/internal/handler/callbacks.go
@@ -22,7 +22,6 @@ func OnMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	ch, err := s.Channel(m.ChannelID)
 	if err != nil {
-		log.Errorf("Error getting channel: %s", err)
 		return
 	}
 	isDM := ch.Type == discordgo.ChannelTypeDM
@@ -39,7 +38,7 @@ func OnMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	// Match user/nick/role/channel mentions
-	mentionRegex := regexp.MustCompile(`<@!?\d+>|<@&\d+>|<#\d+>`)
+	mentionRegex := regexp.MustCompile(`^(<@!?\d+>\s+|<@&\d+>\s+|<#\d+>\s+)`)
 
 	// Remove mentions from the message content
 	content := mentionRegex.ReplaceAllString(m.Content, "")
@@ -56,7 +55,7 @@ func OnMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	if !(isDM || isMention) {
 		var ok bool
 		if strings.HasPrefix(m.Content, "!") {
-			content, ok = strings.CutPrefix(content, Trigger)
+			content, ok = strings.CutPrefix(content, Trigger+" ")
 			if !ok {
 				log.Info("Didn't find trigger")
 				return

--- a/internal/handler/dispatch.go
+++ b/internal/handler/dispatch.go
@@ -2,23 +2,26 @@ package handler
 
 import (
 	"errors"
-
 	"github.com/akl-infra/bot/internal/cmd"
+	"github.com/akl-infra/bot/internal/cmd/cmd_core"
 )
 
 type CommandFunc func(string, []string) (string, error)
 
-var Commands = map[string]CommandFunc{
-	"ping": cmd.Ping,
-	"help": cmd.Help,
-	"list": cmd.List,
-	"view": cmd.View,
+var Commands = map[string]cmd_core.Commandable{
+	"8ball":  cmd.EightBall{},
+	"gh":     cmd.Github{},
+	"github": cmd.Github{},
+	"help":   cmd.Help{},
+	"ping":   cmd.Ping{},
+	"list":   cmd.List{},
+	"view":   cmd.View{},
 }
 
-func Dispatch(command string, args []string) (string, error) {
-	if f, ok := Commands[command]; !ok {
+func Dispatch(command string, arg string, uuid uint64) (string, error) {
+	if commandObject, found := Commands[command]; !found {
 		return "Command not found", errors.New("Command not found")
 	} else {
-		return f(command, args)
+		return commandObject.Exec(arg, uuid)
 	}
 }

--- a/internal/util/parser/parser.go
+++ b/internal/util/parser/parser.go
@@ -1,3 +1,16 @@
 package parser
 
-// TODO: Implement other parser logics
+import (
+	"regexp"
+	"strings"
+)
+
+func ParseQuotedArgs(str string) []string {
+	re := regexp.MustCompile(`[^\s"']+|"([^"]*)"|'([^']*)'`)
+	matches := re.FindAllString(str, -1)
+	return matches
+}
+
+func ParseArgs(str string) []string {
+	return strings.Fields(str)
+}


### PR DESCRIPTION
- New interface `Commandable`
- New default struct `DefaultCommand`
- Implement new commands with `type ExampleCommand struct { cmd_core.DefaultCommand }`
  - required methods: `Exec(string, uint64)`, `Use()`, `Desc()`
  - default methods: `Restricted()`, `ModsOnly`
- renamed `parseArgs` to `ParseQuotedArgs`, moved to `parser` package
- added `8ball` and `github` command
- fixed trigger logic
![Screenshot (90)](https://github.com/akl-infra/bot/assets/96000090/eb3b299d-98e1-4885-ab4b-05ac3647ced7)
*DM*
![Screenshot (92)](https://github.com/akl-infra/bot/assets/96000090/231a091d-41f3-41a1-bec8-e5a09b250649)
*`!akl` trigger in server*
![Screenshot (93)](https://github.com/akl-infra/bot/assets/96000090/188bcc3f-4abb-4078-8ba3-78ca49c3fb7b)
*ping in server*
